### PR TITLE
Fix broken documentation link

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -13,7 +13,7 @@
                                 language features and syntax.
                             </p>
                             <div class="mt-10 flex items-center gap-x-6">
-                                <a href="#"
+                                <a href="/docs"
                                     class="rounded-md bg-purple-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-600">
                                     Documentation
                                 </a>


### PR DESCRIPTION
The documentation button on the homepage is currently broken.